### PR TITLE
Add a basic modal; some cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,23 @@ The documentation I'm following mentions using a virtual env named venv.
 
 Personally, I'm also using ASDF to manage my local Python versions, but this may
 not be necessary for you.
+
+### ngrok
+
+We use ngrok to connect from the local development environment (your computer)
+to the greater internet.
+
+```bash
+$ ngrok http 3000
+```
+
+### local python application
+
+With ngrok underway, you can start the virtual environment and run the app.
+
+```bash
+$ source ./venv/bin/activate
+(.vent)$ python3 app.py
+```
+
+Certain code changes may need you to restart the application.

--- a/app.py
+++ b/app.py
@@ -77,12 +77,6 @@ def create_puzzle(ack, say, command):
   # Announce the new channel
   say(f"New puzzle created")
 
-@app.command("/solve-puzzle")
-def solve_puzzle(ack, say, respond, command):
-  ack()
-  say(f"This would mark puzzle \"{command['text']}\" as solved.")
-  respond(f"This would be seen only by the requestor.")
-
 if __name__ == "__main__":
   # app.start(port=int(os.environ.get("PORT", 3000)))
   handler = SocketModeHandler(app, os.environ["SLACK_APP_TOKEN"])

--- a/app.py
+++ b/app.py
@@ -1,7 +1,9 @@
-import os
+import os, logging
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 from kaiser.sheet import Sheet
+
+logging.basicConfig(level=logging.DEBUG)
 
 app = App(
   token = os.environ.get("SLACK_BOT_TOKEN"),
@@ -56,7 +58,8 @@ def update_home_tab(client, event, logger):
 
 # Listener for mentions
 @app.event("app_mention")
-def simple_response(say):
+def simple_response(say, logger):
+  logger.info("Inside simple_response")
   say("Hi there!")
 
 @app.command("/create-puzzle")

--- a/app.py
+++ b/app.py
@@ -80,6 +80,28 @@ def create_puzzle(ack, say, command):
   # Announce the new channel
   say(f"New puzzle created")
 
+# Listener for the demonstration modal
+@app.shortcut("demonstrate_modal")
+def demonstrate_modal(ack, shortcut, client, logger):
+  ack()
+  client.views_open(
+    trigger_id=shortcut["trigger_id"],
+    view={
+      "type": "modal",
+      "title": {"type": "plain_text", "text": "Demonstration modal box"},
+      "close": {"type": "plain_text", "text": "Close"},
+      "blocks": [
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "This is a demonstration of a modal box invoked by a shortcut. If this were a working form, there would be input boxes and a submit button.\n\nThis is only a demonstration."
+          }
+        }
+      ]
+    }
+  )
+
 if __name__ == "__main__":
   # app.start(port=int(os.environ.get("PORT", 3000)))
   handler = SocketModeHandler(app, os.environ["SLACK_APP_TOKEN"])


### PR DESCRIPTION
This replaces the solve-puzzle command option with a demonstration of how a modal box would work.

Along the way, we also add some documentation about running the app locally, as well as some logging information to the app's operation.

With this change, we can compare the process of handling a modal, versus handling a command-line directive like `/create-puzzle`.
